### PR TITLE
Fix extra bracket in save.sql

### DIFF
--- a/save.sql
+++ b/save.sql
@@ -18,7 +18,6 @@ BOOLEAN AS $$
         var update = plv8.prepare("UPDATE col_" + collection + " SET data = $1 WHERE col_" + collection + "_id = $2", [ 'json', 'character varying' ]);
         res = update.execute([ data, id ]);
       }
-    }
   }
 
   if (res == 0) { // If it didnt affect anything, it must be a new row. Insert.


### PR DESCRIPTION
It looks like there's an extra (unintended) bracket in save.sql

With the bracket:
`CPD-MacBook-Pro:mongolike Admin$ psql Tavern < save.sql
ERROR:  SyntaxError: Unexpected token if
DETAIL:  save() LINE 23:   if (res == 0) { // If it didnt affect anything, it must be a new row. Insert`

With it removed:

```
CPD-MacBook-Pro:mongolike Admin$ psql Tavern < save.sql
CREATE FUNCTION
```
