### PR TITLE
Fix slightly-less-easy install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The easy way to install is to use `node.js`.
     $ npm install -g mongolike
     $ mongolike-install -d yourdb
 
-#### The Slight Less Easy Way
+#### The Slightly Less Easy Way
 
-    $ psql yourdb <sql/*.sql
+    $ for file in sql/*.sql; do psql yourdb < $file; done
 
 ## Running Tests
 


### PR DESCRIPTION
Running the install instructions as documented, I get an error in bash:

``` console
maciek@gamera:~/code/mongolike$ psql mongolike-test <sql/*.sql
bash: sql/*.sql: ambiguous redirect
```

I don't think it's possible to redirect input from multiple files like this. Looping over the files works for me.
